### PR TITLE
From zip to zipruby

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,14 +17,14 @@ PATH
       pry
       rake
       snappy
-      zip
+      zipruby (= 0.3.6)
 
 GEM
   remote: https://rubygems.org/
   specs:
     coderay (1.0.9)
     method_source (0.8.2)
-    minitest (5.0.6)
+    minitest (5.0.7)
     msgpack (0.5.5)
     pry (0.9.12.2)
       coderay (~> 1.0.5)
@@ -35,7 +35,7 @@ GEM
       rake
     slop (3.4.6)
     snappy (0.0.8)
-    zip (2.0.2)
+    zipruby (0.3.6)
 
 PLATFORMS
   ruby

--- a/locationary.gemspec
+++ b/locationary.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rake"
   spec.add_runtime_dependency "msgpack"
   spec.add_runtime_dependency "minitest"
-  spec.add_runtime_dependency "zip"
+  spec.add_runtime_dependency "zipruby", "0.3.6"
   spec.add_runtime_dependency "snappy"
   spec.add_runtime_dependency "pry"
 end


### PR DESCRIPTION
This changes the `zip` dependency in favor of `zipruby`, which is the library in use in the main Shopify repo.

Oren, I haven't found any test to prove that my modification is working. Did I miss one somewhere?

@Sirupsen @orenmazor for review
