### PR TITLE
Make some dependancies dev dependancies.

### DIFF
--- a/locationary.gemspec
+++ b/locationary.gemspec
@@ -18,11 +18,12 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "bundler"
-  spec.add_runtime_dependency "rake"
   spec.add_runtime_dependency "msgpack"
-  spec.add_runtime_dependency "minitest"
   spec.add_runtime_dependency "zipruby", "0.3.6"
   spec.add_runtime_dependency "snappy"
-  spec.add_runtime_dependency "pry"
+
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency 'minitest'
+  spec.add_development_dependency "pry"
 end


### PR DESCRIPTION
@EiNSTeiN- & @byroot for review
cc @camilo

## Problem

I found out that [minitest automatically starts up two threads by default when it is required](https://github.com/seattlerb/minitest/blob/7298fce695b7a386392a293f23e6253576b05473/lib/minitest.rb#L23), so naturally I want to reduce runtime dependancies on minitest.

There is no reason why locationary needs runtime dependancies on it or a few other gems.

## Solution

Use add_development_dependency in the gemspec instead.